### PR TITLE
Readme updates, mocha waiter fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,19 @@ readyness.js
 
 **Readyness** will help you lock some calls and wait until your service is up and running.
 
-Usefull when you have to be sure that your database is connected and server listening before starting your tests.
-
-I personnaly wrote it to be sure that everything was ready before doing any test with mocha.
+Useful when you have to be sure that your database is connected and server listening before starting your tests. Written with mocha in mind.
 
 Pierre-Mikael Legris (Perki)  
 License: "Do whatever you want v2.1"  
-Sponsor: SimpleData Sàrl : simpledata.ch  
+Sponsor: SimpleData SÃ rl : simpledata.ch  
 
 **Install it with** `npm install readyness`
 
-## Exemples 
+## Examples 
  **setup redis readyness (could be your database.js file)**
       
     var ready = require('readyness');
-    ready.setLogger(console.log); // optional, you may set your own preffered logger
+    ready.setLogger(console.log); // optional, you may set your own preferred logger
     
     var redis = require('redis').createClient();
  
@@ -35,11 +33,11 @@ Sponsor: SimpleData Sàrl : simpledata.ch
  
  **lock on server socket opening**
  
-	var appListening = require('readyness').waitFor('app:listening');
-	app.listen(3080, 127.0.0.1, function() {  
-	  // called with a text parameter for debugging purpose
-  	  appListening('Register server on port: '+app.address().port);
-	});
+  var appListening = require('readyness').waitFor('app:listening');
+  app.listen(3080, 127.0.0.1, function() {  
+    // called here with a text parameter for debugging purpose
+      appListening('Register server on port: '+app.address().port);
+  });
 
 
 
@@ -49,34 +47,34 @@ Sponsor: SimpleData Sàrl : simpledata.ch
       before(function(done) {
         require('readyness').doWhen(done);
       });
+      it('readyness.js is ready', function() { return true; });
     });
 
 
 **shortcut to the previous code (waiter for mocha)**
 
-	require('readyness/wait/mocha');
+  require('readyness/wait/mocha');
 
-## Specs
+## Methods
 ### readyness.waitFor(text)
-Returns a function that has to be called when the process is ready.  
-*The **text** parameter is optional, and used for logging purpose.*  
-
-The returned function can be called also with an optional text parameter it will be displayed if you have set a logger.
+Registers a task to be watched.
+Returns a function that has to be called when the task is complete.  
+*The **text** parameter is optional, and used for logging purpose. The returned function can also optionally take a text parameter which will be displayed if you have set a logger.*
 
 ### readyness.doWhen(callback)
-The passed callbacks will be called as soon as the app is ready.
+The passed callbacks will be called as soon as all tasks have been completed.
 
-You may register as many callback as necessary
+You may register as many callbacks as necessary.
 
 ### readyness.setLogger(function)
-If you need some logging put your preffered logger there. 
+If you need some logging put your preferred logger there. 
 It has to be done only once per project.
 
-I'm not very confortable with this solution.. Comments are welcome...  
+I'm not very comfortable with this solution.. Comments are welcome...  
 For now I set the logger once in my main.js file. 
 
 ## Waiter for mocha (and others)
 As I tried to resolve a problem encoutered with mocha, I wrote a little piece of just for it.
-if you add a `require('readyness/wait/mocha');` in the first lines of your tests files, then mocha will not process any test before readyness.
+if you add a `require('readyness/wait/mocha');` in the first lines of your test's files, then mocha will not process any test before readyness.
 
-Contributions for other waiters codes are welcome!
+Contributions of waiters for other testing frameworks are welcome!

--- a/wait/mocha.js
+++ b/wait/mocha.js
@@ -3,8 +3,9 @@
  * to be required ahead of you tests
  */
 
-describe('WAIT readyness.js', function(){
+describe('readyness.js gate', function() {
   before(function(done) {
     require('readyness').doWhen(done);
   });
+  it('is unlocked for testing', function() { return true; });
 });


### PR DESCRIPTION
At some point, there's been a change to mocha which stopped it running before() calls on otherwise empty test suites.